### PR TITLE
Add constructor parameter to support all European energy markets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>de.chiflux</groupId>
   <artifactId>entsoe-client</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.9</version>
+  <version>1.1.0</version>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>Java Library for accessing Day-ahead Prices for Germany on the ENTSO-E Transparency Platform</description>
   <url>https://github.com/chiflux/entsoe-client</url>

--- a/src/main/java/entsoe/EntsoeClient.java
+++ b/src/main/java/entsoe/EntsoeClient.java
@@ -42,8 +42,8 @@ public class EntsoeClient implements EntsoeDefines {
 
     private static final String apiUrl = "https://web-api.tp.entsoe.eu/api"; // The URL of the ENTSOE API
     private static final String documentType = "A44"; // The day ahead prices document
-    private static final String in_Domain = "10Y1001A1001A82H"; // DE_LU (Germany)
-    private static final String out_Domain = in_Domain; // must be the same as in_Domain
+    private String in_Domain;
+    private String out_Domain;
 
     private final ApiRateLimiter apiRateLimiter = new ApiRateLimiter(60, Duration.ofMinutes(1), Duration.ofSeconds(1)); // max 60 requests per minute
 
@@ -54,10 +54,22 @@ public class EntsoeClient implements EntsoeDefines {
      * @param entsoeSecurityToken The ENTSOE_SECURITY_TOKEN as parameter - must not be null
      */
     public EntsoeClient(String entsoeSecurityToken) {
+        this(entsoeSecurityToken, "10Y1001A1001A82H");
+    }
+
+    /**
+     * Explicit constructor that takes the ENTSOE_SECURITY_TOKEN as parameter.
+     * @param entsoeSecurityToken The ENTSOE_SECURITY_TOKEN as parameter - must not be null
+     * @param domain The domain to request the data for, e.g. "10Y1001A1001A82H" for Germany, "10YNL----------L" for the Netherlands
+     * @see <a href="https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html#_areas">ENTSO-E API Guide - Areas</a>
+     */
+    public EntsoeClient(String entsoeSecurityToken, String domain) {
         if (entsoeSecurityToken==null) {
             throw new IllegalArgumentException("entsoeSecurityToken must not be null");
         }
         this.entsoeSecurityToken = entsoeSecurityToken;
+        this.in_Domain = domain;
+        this.out_Domain = domain;
     }
 
     /**


### PR DESCRIPTION
In order to leverage the API client in other markets than just the German one, I've made a change to make the domain/region configurable. For backwards compatibility I've kept the original constructor signature. It would be great if you could merge this PR and could publish an updated dependency. Thanks for your consideration and for the overall project!